### PR TITLE
added functionality so that in case of multiple commands setting the …

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Default config settings of the fields plugin.
+ */
+
+$conf['firstfielddefinitionwins'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Options for the fields plugin
+ */
+ 
+$meta['firstfielddefinitionwins']   = array('onoff');

--- a/lang/de-informal/settings.php
+++ b/lang/de-informal/settings.php
@@ -1,0 +1,5 @@
+<?php
+
+/**
+ */
+$lang['firstfielddefinitionwins'] = 'Bei mehreren Definitionen von field auf einer Seite wird die erste verwendet. (Im Fall von false, wird das letzte verwendet.)';

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -1,0 +1,5 @@
+<?php
+
+/**
+ */
+$lang['firstfielddefinitionwins'] = 'Bei mehreren Definitionen von field auf einer Seite wird die erste verwendet. (Im Fall von false, wird das letzte verwendet.)';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * English language file for config settings.
+ */
+$lang['firstfielddefinitionwins'] = 'In case of multiple definitions of a particular field, the first will be used. (The value false will apply the last definition, instead.)';

--- a/syntax.php
+++ b/syntax.php
@@ -16,7 +16,8 @@ class syntax_plugin_fields extends DokuWiki_Syntax_Plugin {
      * Constructor. Loads helper plugin.
      */
     public function __construct() {
-        $this->helper = $this->loadHelper('fields');
+        $this->fields_helper = plugin_load('helper','fields');
+        $this->usecounter_helper = plugin_load('helper','usecounter');
     }
 
     /**
@@ -70,7 +71,7 @@ class syntax_plugin_fields extends DokuWiki_Syntax_Plugin {
                 $renderer->doc .= $renderer->fields[$field_name];
                 return true;
             } elseif ($format == 'odt') {
-                $renderer->doc .= $this->helper->ODTDisplayUserField($renderer, $field_name);
+                $renderer->doc .= $this->fields_helper->ODTDisplayUserField($renderer, $field_name);
                 return true;
             }
         } else {
@@ -82,8 +83,17 @@ class syntax_plugin_fields extends DokuWiki_Syntax_Plugin {
                 $renderer->fields[$field_name] = htmlentities($field_value);
                 return true;
             } elseif ($format == 'odt') {
-                $this->helper->ODTSetUserField($renderer, $field_name,
-                    $renderer->_xmlEntities($field_value));
+                if ($this->getConf('firstfielddefinitionwins')) {
+                    if ($this->usecounter_helper && $this->usecounter_helper->amountOfUses('fields_'.$field_name) == 0) {
+                        $this->fields_helper->ODTSetUserField($renderer, $field_name, $renderer->_xmlEntities($field_value));
+                    }
+                    
+                    if ($this->usecounter_helper) {
+                        $this->usecounter_helper->incUsageOf('fields_'.$field_name);
+                    }
+                } else {
+                    $this->fields_helper->ODTSetUserField($renderer, $field_name, $renderer->_xmlEntities($field_value));
+                }
                 return true;
             }
         }


### PR DESCRIPTION
…same field will result in only the first field being set

Adds a boolean configuration option 'firstfielddefinitionwins'. If set to true, the new functionality will be active (first occurrence will set the field value). If set to false, the old behavior will be used (last occurrence will set the field value).

**Important dependency:** only works if the [usecounter](https://www.dokuwiki.org/plugin:usecounter) plugin is installed, as well!

resolves #8 