### PR TITLE
Make syntax.php PHP8 friendly

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -53,7 +53,7 @@ class syntax_plugin_fields extends DokuWiki_Syntax_Plugin {
         } elseif (count($extinfo) == 2) {
             $field_value = $extinfo[1];
         } else { // value may contain equal signs
-            $field_value = implode(array_slice($extinfo,1), '=');
+            $field_value = implode('=', array_slice($extinfo,1));
         }
         return array($field_name, $field_value);
     }


### PR DESCRIPTION
we use the new function signature for implode. This function now use the separator first since PHP8.